### PR TITLE
Contributors url changed to to show public profiles. Related issue: #14

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ sass:
 urls:
   releases: https://github.com/tuist/tuist/releases
   github: https://github.com/tuist
-  contributors: https://github.com/orgs/tuist/teams/contributors
+  contributors: https://github.com/orgs/tuist/people
   pedro: https://ppinera.com
   website_repository: https://github.com/tuist/website
   patreon: https://www.patreon.com/tuist


### PR DESCRIPTION
This PR simply changes URL to contributors list. New URL will show public profiles for every user. Old one showed profiles only for organization members.

Resolves https://github.com/tuist/website/issues/14

* [ ] Open `Tuist.org contributors` url from website header.

![image](https://user-images.githubusercontent.com/4790464/47786753-744c2880-dd15-11e8-99de-0cad3a17f978.png)

