### PR TITLE
Fix for Imrpove section url of Vision page

### DIFF
--- a/_includes/improve.html
+++ b/_includes/improve.html
@@ -1,3 +1,3 @@
 <p class="page__improve-paragraph">
-  Got improvements? Help improve this document via <a href="{{site.urls.website_repository}}/edit/master/collections/{{page["path"]}}" target="__blank">sending PRs</a>.
+  Got improvements? Help improve this document via <a href="{{site.urls.website_repository}}/edit/master/{% if page.collection %}collections/{{ page["relative_path"] }}{% else %}{{ page["path"] }}{% endif %}" target="__blank">sending PRs</a>.
 </p>

--- a/collections/_guides/3-build-and-test.md
+++ b/collections/_guides/3-build-and-test.md
@@ -2,6 +2,7 @@
 layout: page
 title: Build and test
 excerpt: This is a summary of this page. This is a summary of this page. This is a summary of this page
+published: false
 ---
 
 asdgasd


### PR DESCRIPTION
Original issue: 
URL `sending PRs` in Improve section of Vision page was not working:
![image](https://user-images.githubusercontent.com/4790464/47789137-68b03000-dd1c-11e8-8763-a83fc79e860d.png)


### Short description 📝
This PR:
- Fixes URL for pages not in collections folder in `Improve` section.
- Marks guide [Build and test](https://github.com/tuist/website/blob/master/collections/_guides/3-build-and-test.md) as `published: false` so it won't be shown at tuist.io

### Solution 📦

We check if page is in collection:
- If it is — we use "collections/{page.relative_path" as last path components
- Otherwise wee use "page["path"]"

How to verify fixes: 
 1) [ ] bundle exec jekyll serve
 2) [ ] Verify that URL in `Got improvements? Help improve this document via sending PRs.` section at the bottom of the page works for following items:
      - Blog posts list
      - Specific guides
      - Vision page