### PR TITLE
Fix Sponsorship urls in main navigation and blog posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@astrolib/seo": "^0.4.0",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
+    "@tuist/website": "link:",
     "astro-compress": "^1.1.27",
     "install": "^0.13.0",
     "markdown-it": "^13.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   '@tailwindcss/line-clamp':
     specifier: ^0.4.2
     version: 0.4.2(tailwindcss@3.2.7)
+  '@tuist/website':
+    specifier: 'link:'
+    version: 'link:'
   astro-compress:
     specifier: ^1.1.27
     version: 1.1.27

--- a/src/components/global/Navigation.astro
+++ b/src/components/global/Navigation.astro
@@ -79,7 +79,7 @@ import metadata from "../../utils/metadata.json";
         >
 
         <a
-          href={metadata["sponsor"]["paragraph"]}
+          href={metadata["sponsor"]["link"]}
           class="inline-flex items-center justify-center px-6 py-2 text-sm text-center text-white hover:to-indigo-400 duration-200 bg-gradient-to-r from-sky-400 to-indigo-500 font-medium hover:bg-white/5 rounded-xl hover:text-white focus:outline-none focus-visible:outline-black focus-visible:ring-black lg:ml-auto">
           Sponsor
         </a>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -183,7 +183,7 @@ const { Content } = await entry.render();
               <a
                 class="inline-flex items-center justify-center w-full px-6 py-3 text-center text-white hover:to-indigo-400 duration-200 bg-gradient-to-r from-sky-400 to-indigo-500 font-medium rounded-xl hover:text-white focus:outline-none focus-visible:outline-black focus-visible:ring-black mt-8 no-underline"
                 aria-label="Sponsor Tuist"
-                href={metadata["sponsor"]["url"]}>Sponsor Tuist</a
+                href={metadata["sponsor"]["link"]}>Sponsor Tuist</a
               >
             </div>
           </div>


### PR DESCRIPTION
Hi, this small PR fixes same issue in 2 different places:
- 404 issue when `Sponsor` button is clicked in Main Navigation component
- Non-clickable `Sponsor` button in blog posts