### PR TITLE
Make testimonies dynamic

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "install": "^0.13.0",
     "markdown-it": "^13.0.1",
     "mdx-embed": "^1.1.2",
-    "preact": "^10.6.5",
+    "preact": "^10.16.0",
     "sanitize-html": "^2.11.0",
     "satori": "^0.10.1",
     "sharp": "^0.32.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ dependencies:
     specifier: ^1.1.2
     version: 1.1.2
   preact:
-    specifier: ^10.6.5
+    specifier: ^10.16.0
     version: 10.16.0
   sanitize-html:
     specifier: ^2.11.0
@@ -1201,7 +1201,7 @@ packages:
   /@types/sax@1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 20.3.1
+      '@types/node': 20.4.5
     dev: false
 
   /@types/sharp@0.31.1:

--- a/src/components/testimonials/RandomTestimonial.jsx
+++ b/src/components/testimonials/RandomTestimonial.jsx
@@ -1,0 +1,91 @@
+export default function RandomTestimonial({ testimonials }) {
+  const testimony =
+    testimonials[Math.floor(Math.random() * testimonials.length)];
+
+  return (
+    <div className="p-4 lg:p-10 text-center basis-2/3">
+      <img
+        className="inline-block h-10 w-10 rounded-full ring-2 ring-white ring-offset-4 ring-offset-vulcan-900"
+        src={testimony.data.avatar_href}
+        alt=""
+      />
+
+      <div>
+        <p className="text-slate-400 text-xs mt-8">
+          <strong className="text-white">{testimony.data.name}</strong> ―{" "}
+          {testimony.data.role} at {testimony.data.company}
+        </p>
+      </div>
+      <div className="mt-4 text-base text-slate-400 line-clamp-10">
+        {testimony.data.testimony}
+      </div>
+      <div className="flex gap-1 mx-auto justify-center mt-6">
+        <svg
+          className="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
+          fill="currentColor"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          xmlns="http://www.w3.org/2000/svg"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
+          <path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"></path>
+        </svg>
+        <svg
+          className="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
+          fill="currentColor"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          xmlns="http://www.w3.org/2000/svg"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
+          <path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"></path>
+        </svg>
+        <svg
+          className="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
+          fill="currentColor"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          xmlns="http://www.w3.org/2000/svg"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
+          <path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"></path>
+        </svg>
+        <svg
+          className="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
+          fill="currentColor"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          xmlns="http://www.w3.org/2000/svg"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
+          <path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"></path>
+        </svg>
+        <svg
+          className="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
+          fill="currentColor"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          xmlns="http://www.w3.org/2000/svg"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
+          <path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"></path>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/components/testimonials/TestimonialOne.astro
+++ b/src/components/testimonials/TestimonialOne.astro
@@ -1,8 +1,8 @@
 ---
 import Verticalgrid from "../assets/VerticalGrid.astro";
 import { getCollection } from "astro:content";
+import RandomTestimonial from "./RandomTestimonial.jsx";
 const allTestimonials = await getCollection('testimonials')
-const testimony = allTestimonials[Math.floor(Math.random() * allTestimonials.length)]
 ---
 
 <section
@@ -29,94 +29,7 @@ const testimony = allTestimonials[Math.floor(Math.random() * allTestimonials.len
   <div class="pb-24">
     <div class="mx-auto">
       <div class="flex flex-row justify-center">
-        <div class="p-4 lg:p-10 text-center basis-2/3">
-          <img
-            class="inline-block h-10 w-10 rounded-full ring-2 ring-white ring-offset-4 ring-offset-vulcan-900"
-            src={testimony.data.avatar_href}
-            alt=""
-          />
-
-          <div>
-            <p class="text-slate-400 text-xs mt-8">
-              <strong class="text-white">{testimony.data.name}</strong> ― {testimony.data.role} at {testimony.data.company}
-            </p>
-          </div>
-          <div class="mt-4 text-base text-slate-400 line-clamp-10">
-            {testimony.data.testimony}
-          </div>
-          <div class="flex gap-1 mx-auto justify-center mt-6">
-            <svg
-              class="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
-              fill="currentColor"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              xmlns="http://www.w3.org/2000/svg"
-              stroke-linecap="round"
-              stroke-linejoin="round">
-              <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
-              <path
-                d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"
-              ></path>
-            </svg>
-            <svg
-              class="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
-              fill="currentColor"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              xmlns="http://www.w3.org/2000/svg"
-              stroke-linecap="round"
-              stroke-linejoin="round">
-              <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
-              <path
-                d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"
-              ></path>
-            </svg>
-            <svg
-              class="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
-              fill="currentColor"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              xmlns="http://www.w3.org/2000/svg"
-              stroke-linecap="round"
-              stroke-linejoin="round">
-              <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
-              <path
-                d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"
-              ></path>
-            </svg>
-            <svg
-              class="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
-              fill="currentColor"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              xmlns="http://www.w3.org/2000/svg"
-              stroke-linecap="round"
-              stroke-linejoin="round">
-              <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
-              <path
-                d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"
-              ></path>
-            </svg>
-            <svg
-              class="icon icon-tabler fill-cyan-400 h-4 icon-tabler-star text-cyan-400 w-4"
-              fill="currentColor"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              xmlns="http://www.w3.org/2000/svg"
-              stroke-linecap="round"
-              stroke-linejoin="round">
-              <path d="M0 0h24v24H0z" fill="none" stroke="none"></path>
-              <path
-                d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z"
-              ></path>
-            </svg>
-          </div>
-        </div>
+        <RandomTestimonial testimonials={allTestimonials} client:load/>
       </div>
     </div>
   </div>

--- a/src/content/testimonials/shahzad.json
+++ b/src/content/testimonials/shahzad.json
@@ -3,6 +3,6 @@
     "role": "Senior Lead Software Engineer",
     "company": "DraftKings",
     "testimony": "Tuist has revolutionized our iOS development workflow at DraftKings. Its automation capabilities have streamlined project generation, build settings, and dependency management. With modularization, we maximize code sharing across apps, reducing duplication.",
-    "avatar_href": "https://media.licdn.com/dms/image/C4D03AQHYGKlUJE6QpQ/profile-displayphoto-shrink_800_800/0/1549777725180?e=1692230400&v=beta&t=2EEiTmnljofydqd9n8dp4qci_on_x-yOWIkeq4DBHtk"
+    "avatar_href": "https://avatars.githubusercontent.com/u/1209459?v=4"
   }
   


### PR DESCRIPTION
## Problem

@danyf90 noticed that the website always loaded the same testimony. It turns out that Astro generates the pages statically at deploy time meaning that it binds the index page to one of the testimonies. That's why every time the page is loaded it loads the same one.

## Solution

Astro supports loading dynamic components when the page loads. This PR leverages that feature to load a Preact component which dynamically draws a random testimony and uses is to lay out the component.