### PR TITLE
Include the cal.com badge in the footer

### DIFF
--- a/src/components/global/Footer.astro
+++ b/src/components/global/Footer.astro
@@ -6,24 +6,60 @@ import metadata from "../../utils/metadata.json";
 <footer
   aria-labelledby="footer"
   id="footer "
-  class="bg-vulcan-900 relative border-t border-white/5">
+  class="bg-vulcan-900 relative border-t border-white/5"
+>
   <Blurgradientleft />
   <div class="max-w-7xl px-8 md:px-12 lg:px-32 mx-auto py-12 lg:py-24 relative">
     <div class="space-y-10 xl:space-y-0 xl:grid xl:grid-cols-4 xl:gap-8">
       <div class="text-white">
         <div class="inline-flex items-center gap-3">
-          <svg  class="h-10" id="logo-70" viewBox="0 0 407 407" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="203.5" cy="203.5" r="203.5" fill="url(#paint0_linear_101_5)"/>
-            <path d="M100.902 294.082C100.902 294.082 143.722 328.144 204.772 328.144C265.822 328.144 308.642 294.082 308.642 294.082" stroke="white" stroke-width="10.175"/>
-            <path d="M89.0312 236.259C89.0312 236.259 163.224 325.6 204.772 325.6C246.32 325.6 320.513 236.259 320.513 236.259" stroke="white" stroke-width="10.175"/>
-            <path d="M89.0312 164.785C89.0312 164.785 163.224 325.6 204.772 325.6C246.32 325.6 320.513 164.785 320.513 164.785" stroke="white" stroke-width="10.175"/>
-            <path d="M136.515 102.246C136.515 102.246 183.15 325.6 204.772 325.6C226.394 325.6 273.029 102.246 273.029 102.246" stroke="white" stroke-width="10.175"/>
-            <line x1="205.62" y1="325.6" x2="205.62" y2="81.4" stroke="white" stroke-width="10.175"/>
+          <svg
+            class="h-10"
+            id="logo-70"
+            viewBox="0 0 407 407"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="203.5"
+              cy="203.5"
+              r="203.5"
+              fill="url(#paint0_linear_101_5)"></circle>
+            <path
+              d="M100.902 294.082C100.902 294.082 143.722 328.144 204.772 328.144C265.822 328.144 308.642 294.082 308.642 294.082"
+              stroke="white"
+              stroke-width="10.175"></path>
+            <path
+              d="M89.0312 236.259C89.0312 236.259 163.224 325.6 204.772 325.6C246.32 325.6 320.513 236.259 320.513 236.259"
+              stroke="white"
+              stroke-width="10.175"></path>
+            <path
+              d="M89.0312 164.785C89.0312 164.785 163.224 325.6 204.772 325.6C246.32 325.6 320.513 164.785 320.513 164.785"
+              stroke="white"
+              stroke-width="10.175"></path>
+            <path
+              d="M136.515 102.246C136.515 102.246 183.15 325.6 204.772 325.6C226.394 325.6 273.029 102.246 273.029 102.246"
+              stroke="white"
+              stroke-width="10.175"></path>
+            <line
+              x1="205.62"
+              y1="325.6"
+              x2="205.62"
+              y2="81.4"
+              stroke="white"
+              stroke-width="10.175"></line>
             <defs>
-            <linearGradient id="paint0_linear_101_5" x1="203.5" y1="0" x2="203.5" y2="407" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#6236FF"/>
-            <stop offset="1" stop-color="#3000DA"/>
-            </linearGradient>
+              <linearGradient
+                id="paint0_linear_101_5"
+                x1="203.5"
+                y1="0"
+                x2="203.5"
+                y2="407"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stop-color="#6236FF"></stop>
+                <stop offset="1" stop-color="#3000DA"></stop>
+              </linearGradient>
             </defs>
           </svg>
           <p class="text-2xl font-bold">Tuist</p>
@@ -33,6 +69,15 @@ import metadata from "../../utils/metadata.json";
             © 2023 Tuist. <br /> All rights reserved
           </span>
         </p>
+        <a
+          href="https://cal.com/team/tuist/cloud?utm_source=banner&utm_campaign=oss"
+          target="_blank"
+          ><img
+            class="mt-6"
+            alt="Book us with Cal.com"
+            src="https://cal.com/book-with-cal-light.svg"
+          /></a
+        >
       </div>
       <div class="grid grid-cols-2 gap-8 xl:col-span-3">
         <div class="md:grid md:grid-cols-2 md:gap-8">
@@ -49,7 +94,8 @@ import metadata from "../../utils/metadata.json";
               <li>
                 <a
                   href="https://tuist.github.io/tuist/main/documentation/projectdescription"
-                  class="text-sm text-slate-400 hover:text-white">
+                  class="text-sm text-slate-400 hover:text-white"
+                >
                   Reference
                 </a>
               </li>
@@ -61,21 +107,24 @@ import metadata from "../../utils/metadata.json";
               <li>
                 <a
                   href="https://github.com/tuist/tuist"
-                  class="text-sm text-slate-400 hover:text-white">
+                  class="text-sm text-slate-400 hover:text-white"
+                >
                   Tuist
                 </a>
               </li>
               <li>
                 <a
                   href="https://github.com/tuist/XcodeProj"
-                  class="text-sm text-slate-400 hover:text-white">
+                  class="text-sm text-slate-400 hover:text-white"
+                >
                   XcodeProj
                 </a>
               </li>
               <li>
                 <a
                   href="https://github.com/tuist/awesome-tuist"
-                  class="text-sm text-slate-400 hover:text-white">
+                  class="text-sm text-slate-400 hover:text-white"
+                >
                   awesome-tuist
                 </a>
               </li>
@@ -89,14 +138,16 @@ import metadata from "../../utils/metadata.json";
               <li>
                 <a
                   href="https://join.slack.com/t/tuistapp/shared_invite/zt-1y667mjbk-s2LTRX1YByb9EIITjdLcLw"
-                  class="text-sm text-slate-400 hover:text-white">
+                  class="text-sm text-slate-400 hover:text-white"
+                >
                   Slack
                 </a>
               </li>
               <li>
                 <a
                   href="https://github.com/tuist/tuist/discussions"
-                  class="text-sm text-slate-400 hover:text-white">
+                  class="text-sm text-slate-400 hover:text-white"
+                >
                   Discussions
                 </a>
               </li>
@@ -108,14 +159,16 @@ import metadata from "../../utils/metadata.json";
               <li>
                 <a
                   href="https://twitter.com/tuistio"
-                  class="text-sm text-slate-400 hover:text-white">
+                  class="text-sm text-slate-400 hover:text-white"
+                >
                   Twitter
                 </a>
               </li>
               <li>
                 <a
                   href="https://mastodon.social/@tuist@fosstodon.org"
-                  class="text-sm text-slate-400 hover:text-white">
+                  class="text-sm text-slate-400 hover:text-white"
+                >
                   Mastodon
                 </a>
               </li>


### PR DESCRIPTION
Related [PR](https://github.com/tuist/tuist/pull/5423)

We started using [cal.com](https://cal.com) with users interested in trying Tuist Cloud. Cal.com is a paid service but has a free plan for [open source projects](https://cal.com/docs/how-to-guides/can-calcom-sponsor-my-open-source-project#sponsorship-criteria). One requirement is to add a link to Cal.com to the footer of the website. This PR adds the badge to the footer.