### PR TITLE
Add link to handbook

### DIFF
--- a/src/components/global/Footer.astro
+++ b/src/components/global/Footer.astro
@@ -153,6 +153,14 @@ const translatedPath = useTranslatedPath(lang);
               </li>
               <li>
                 <a
+                  href={"https://handbook.tuist.io"}
+                  class="text-sm text-slate-400"
+                >
+                  {t('footer.company.handbook')}
+                </a>
+              </li>
+              <li>
+                <a
                   href="https://status.tuist.io"
                   class="text-sm text-slate-400"
                 >

--- a/src/components/global/Navigation.astro
+++ b/src/components/global/Navigation.astro
@@ -76,6 +76,11 @@ const languageTranslatedPaths = Object.fromEntries(Object.keys(languages).map((d
           href="https://github.com/tuist/tuist">{t("nav.github")}</a
         >
 
+        <a
+          class="px-2 lg:px-6 py-2 md:px-3 text-sm text-white font-normal hover:text-white/50"
+          href="https://handbook.tuist.io">{t("nav.handbook")}</a
+        >
+
         <div class="flex flex-col md:margin-y-2 space-y-6 mt-3 lg:mt-0 lg:space-y-0 lg:flex-row items-center lg:ml-auto md:space-x-6">
           <div class="relative inline-block" x-data="{ open: false }">
             <button class="text-white uppercase flex flex-row items-center text-sm" x-on:click="open = ! open">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -89,6 +89,7 @@
   "footer.community": "Community",
   "footer.company.about": "About",
   "footer.company.longevity_manifesto": "Longevity Manifesto",
+  "footer.company.handbook": "Handbook",
   "footer.company.tuist_cloud_cookie": "Cookie Policy",
   "footer.company.tuist_cloud_privacy": "Privacy Policy",
   "footer.company.tuist_cloud_status": "Status",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -156,6 +156,7 @@
   "nav.cloud": "Tuist Cloud",
   "nav.docs": "Docs",
   "nav.github": "GitHub",
+  "nav.handbook": "Handbook",
   "nav.slack": "Slack",
   "privacy.og.description": "Tuist Cloud Privacy Policy",
   "privacy.og.image.footer": "tuist.io · @tuistio",


### PR DESCRIPTION
We want Tuist to be an open company like GitLab. As part of that effort, we are making the company's handbook publicly available at https://handbook.tuist.io on the repository https://github.com/tuist/handbook, which will build on standard markdown, and we'll use [Obsidian](https://obsidian.md/) for a great editing experience.
This PR includes the handbook link, website navigation, and footer. 