### PR TITLE
Write a blog post sharing the new vision that we have for Tuist

### DIFF
--- a/src/content/posts/2024/05/22/a-new-tuist.mdx
+++ b/src/content/posts/2024/05/22/a-new-tuist.mdx
@@ -1,0 +1,14 @@
+---
+title: "Evolving Tuist into your platform team"
+categories: ["Swift", "XcodeProj", "Xcode"]
+excerpt: ""
+author: pepicrft
+---
+
+Tuist has become an indispensable tool for [many organizations](https://medium.com/bumble-tech/scaling-ios-at-bumble-76754fa874f7) to **manage and work with the complexities inherent in Xcode projects.** We met developers where they are by providing an ergonomic [Swift-based DSL](https://docs.tuist.io/guide/project/manifests.html) to describe projects of any size, and workflows that leverage that knowledge to automate the most common tasks in Xcode projects. By working closely with developers and organizations, we identified the most common challenges when working with Xcode and codified them in the tool and its [documentation](https://docs.tuist.io).
+
+In October last year, we decided to **focus on financially sustaining the project** to ensure that we could support those organizations that trust us in the long term. The result was *Tuist GmbH*, a company we registered in Germany, and [Tuist Cloud](https://tuist.io/cloud), a service that extends Tuist with paid features. During this time, working with our first customers and chatting with other founders in the developer tooling area, we refined our mental models around what Tuist is and the role it can play in the industry. What follows is a reflection on that journey and the future we envision for Tuist.
+
+## xxx
+
+When we think of organizations development apps


### PR DESCRIPTION
I started dumping the new vision that we have for Tuist, which we've refined through conversations with early customers and other funders. Writing is useful not only for users to understand where the project is headed but also for structuring all the ideas that are currently a mess in our heads.