### PR TITLE
Fix a broken link to `/cloud`

### DIFF
--- a/src/components/features/TuistCloud.astro
+++ b/src/components/features/TuistCloud.astro
@@ -36,7 +36,7 @@ const translatedPath = useTranslatedPath(lang);
           <a
             class="inline-flex items-center justify-center px-6 py-3 text-center text-white hover:to-indigo-400 duration-200 bg-gradient-to-r from-sky-400 to-indigo-500 font-medium rounded-xl hover:text-white focus:outline-none focus-visible:outline-black focus-visible:ring-black mt-8 no-underline"
             aria-label="Sign up for testing"
-            href={translatedPath("/cloud")}
+            href={"https://docs.tuist.io/guides/develop/build/cache"}
           >
             {t("home.cloud.cta")}
           </a>


### PR DESCRIPTION
A developer reported a broken link to `/cloud`. That page no longer exists, so I'm adjusting it to point to [the cache page](https://docs.tuist.io/guides/develop/build/cache), which is the feature they are usually interested in. From there they can learn about the others and also about the Tuist server and how it can extend the capabilities of Tuist.