### PR TITLE
Redirect to tuist.dev

### DIFF
--- a/.mise/tasks/deploy
+++ b/.mise/tasks/deploy
@@ -3,4 +3,9 @@
 
 set -euo pipefail
 
-pnpm run -C $MISE_PROJECT_ROOT deploy
+pnpm -C $MISE_PROJECT_ROOT exec astro build
+cat <<EOT > $MISE_PROJECT_ROOT/dist/_redirects
+https://tuist.io/* https://tuist.dev/:splat 301
+http://tuist.io/* http://tuist.dev/:splat 301
+EOT
+pnpm -C $MISE_PROJECT_ROOT wrangler pages deploy dist --project-name tuist-website --branch main

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "astro": "astro",
-    "deploy": "astro build && wrangler pages deploy dist --project-name tuist-website --branch main"
+    "astro": "astro"
   },
   "devDependencies": {
     "@astrojs/tailwind": "^5.0.0",


### PR DESCRIPTION
We should merge this one after [this](https://github.com/tuist/server/pull/1085) to redirect the marketing traffic to the new instance.